### PR TITLE
Fixed problem with context menu if toolbars are repositioned

### DIFF
--- a/writer.py
+++ b/writer.py
@@ -471,23 +471,10 @@ class Main(QtGui.QMainWindow):
         if table or hyperlink:
 
             # Convert the widget coordinates into global coordinates
-            pos = self.mapToGlobal(pos)
-
-            # Add pixels for the tool and formatbars, which are not included
-            # in mapToGlobal(), but only if the two are currently visible and
-            # not toggled by the user
-
-            if self.toolbar.isVisible():
-                pos.setY(pos.y() + 45)
-
-            if self.formatbar.isVisible():
-                pos.setY(pos.y() + 45)
+            pos = self.text.mapToGlobal(pos)
 
             # Create new menu
-            menu = QtGui.QMenu(self)
-
-            # Move the menu to the new position
-            menu.move(pos)
+            menu = QtGui.QMenu(self.text)
 
             # Add actions for hyperlinks if available
             if hyperlink:
@@ -573,7 +560,7 @@ class Main(QtGui.QMainWindow):
                 menu.addAction(mergeAction)
                 menu.addAction(splitAction)
 
-            menu.show()
+            menu.exec_(pos)
 
         else:
 


### PR DESCRIPTION
I noticed that if a toolbar is repositioned (docked on the left side, for example), then the custom context menu appears in the wrong place.  I fixed it by parenting the QMenu instance properly and removing the 45 pixel offset hacks.

Thanks for the great editor and accompanying tutorial!
